### PR TITLE
Bug Fix: should translate status code Symbol to right HTTP STATUS CODE

### DIFF
--- a/lib/egregious.rb
+++ b/lib/egregious.rb
@@ -13,7 +13,8 @@ module Egregious
 
   def self.status_code(status)
     if status.is_a?(Symbol)
-      Rack::Utils::HTTP_STATUS_CODES[status] || 500
+      key = status.to_s.split("_").map {|e| e.capitalize}.join(" ")
+      Rack::Utils::HTTP_STATUS_CODES.invert[key] || 500
     else
       status.to_i
     end

--- a/spec/egregious_spec.rb
+++ b/spec/egregious_spec.rb
@@ -6,6 +6,13 @@ end
 include Egregious
 
 describe Egregious do
+
+  describe 'status_code' do
+    it "should translate Symbol to right HTTP STATUS CODE" do
+      status_code(:bad_request).should == 400
+    end
+  end
+
   describe 'clean_backtrace ' do
     it "should return nil" do
       clean_backtrace(Exception.new).should == nil


### PR DESCRIPTION
A status code symbol like :bad_request is not currently translated to 400 using Rack::Utils::HTTP_STATUS_CODES..

This pull request fixes this bug..
